### PR TITLE
updating default location

### DIFF
--- a/pybamview/bam_alignment.py
+++ b/pybamview/bam_alignment.py
@@ -49,6 +49,32 @@ def GetSamplesFromBamFiles(bamfiles):
                 samplesToBam[sample] = samplesToBam.get(sample, []) + [bam]
     return samplesToBam
 
+def GetDefaultLocation(bamfiles):
+    """
+    Return default location to jump to if no location given.
+    Look at the first read we see and go there.
+    If no reads aligned, return 'error'
+    """
+    default_chrom = None
+    default_pos = None
+    for bam in bamfiles:
+        try:
+            br = pysam.Samfile(bam, "rb")
+        except:
+            sys.stderr.write("ERROR: Could not open %s. Is this a valid bam file?\n"%bam)
+            continue
+        # Peak at the first read
+        try:
+            aligned_read = br.next()
+        except StopIteration:
+            continue
+        if not aligned_read.is_unmapped:
+            default_chrom = br.getrname(aligned_read.tid)
+            default_pos = aligned_read.pos
+            break
+    if default_chrom is None: return "error"
+    else: return "%s:%s"%(default_chrom, default_pos)
+
 def HashSample(sample):
     """
     Return sample hash

--- a/scripts/pybamview
+++ b/scripts/pybamview
@@ -153,10 +153,12 @@ def display_bam():
             samples_toinclude.append(s.split(":")[0])
             for item in s.split(":")[1:]:
                 bamfiles_toinclude.extend(item.split(","))
-    region = request.args.get("region","chr1:0")
+    region = request.args.get("region", pybamview.GetDefaultLocation(bamfiles_toinclude))
     return display_bam_region(list(set(bamfiles_toinclude)), samples_toinclude, region, zoomlevel)
 
 def display_bam_region(bamfiles, samples, region, zoomlevel):
+    if region == "error":
+        return render_template("error.html", message="No aligned reads found in the selected BAM files")
     for bam in bamfiles:
         if not os.path.exists(join(BAMDIR,bam)):
             MESSAGE("bam file %s does not exist"%join(BAMDIR, bam), WARNING)
@@ -167,10 +169,8 @@ def display_bam_region(bamfiles, samples, region, zoomlevel):
     try:
         chrom, pos = region.split(":")
         pos = int(pos)
-    except: 
-        try:
-            chrom, pos = sorted(bv.reference.keys())[0], 0
-        except: chrom, pos = "None", 0
+    except:
+        return render_template("error.html", message="Invalid region specified %s. Region must be of the form chrom:position."%region)
     bv.LoadAlignmentGrid(chrom, pos, _samples=samples, _settings=SETTINGS)
     positions = bv.GetPositions(pos)
     region = "%s:%s"%(chrom, pos)


### PR DESCRIPTION
Use a reasonable default location, not "chr1:0" which has been used so far. This is discussed in issue #27. Here I look at the first read in each bam file (in arbitrary order) until I find one with alignment info. If it's there, we jump to the first place we found any reads. If there are no aligned reads, return an error page.
