### PR TITLE
removing pandas requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ PyBamView requires Python2.6 or greater. The following python packages are requi
 * ```Flask```
 * ```pysam```
 * ```pyfasta```
-* ```pandas```
 
 These can all be installed using ```pip``` or ```easy_install```. Additionally, the package ```rsvg-convert``` is required for exporting alignment snapshots to PDF.
 

--- a/README.txt
+++ b/README.txt
@@ -11,12 +11,11 @@ LICENSE: MIT (see LICENSE.txt)
 
 Requirements
 ==========
-PyBamView requires Python2.7 or greater. The following python packages are required:
+PyBamView requires Python2.6 or greater. The following python packages are required:
 
 * ```Flask```
 * ```pysam```
 * ```pyfasta```
-* ```pandas```
 
 These can all be installed using ```pip``` or ```easy_install```. Additionally, the package ```rsvg-convert``` is required for exporting alignment snapshots to PDF.
 

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ setup(name=NAME,
       package_data={'pybamview': ['data/css/*.css', 'data/javascript/*.js', 'data/static/*.ico', 'data/static/*.png', 'data/templates/*.html', 'tests/data/*']},
       scripts=['scripts/pybamview'],
       test_suite='pybamview.tests',
-      install_requires=['argparse','flask','pandas','pyfasta','pysam'],
+      install_requires=['flask','pyfasta','pysam'],
       classifiers=['Development Status :: 4 - Beta',\
-                       'Programming Language :: Python :: 2.7',\
+                       'Programming Language :: Python :: 2.6',\
                        'License :: OSI Approved :: MIT License',\
                        'Operating System :: OS Independent',\
                        'Intended Audience :: Science/Research',\


### PR DESCRIPTION
Don't require pandas. Almost all code requiring pandas had been removed anyway, and all remaining code can easily be accomplished using dictionaries. pandas is a pretty big library and best to not require it if we don't really need it.
